### PR TITLE
TON Staker에게 에어드랍하기 위한 Vault 컨트랙트에 잘못 설정된 주소 변경

### DIFF
--- a/scripts/factory/h1_deploy_tonVaultFactory.js
+++ b/scripts/factory/h1_deploy_tonVaultFactory.js
@@ -30,7 +30,7 @@ async function main() {
   const logicaddr = "0xaf96340E1Bfaf7DD5B58a4188a3E2Cb4586E7BdD"
   const upgradeaddr = "0x15280a52E79FD4aB35F4B9Acbb376DCD72b44Fd1"
   const eventAddr = "0x508d5FaDA6871348A5b4fb66f4A1F58b187Ce9Bd"
-  const dividedAddr = "0x9aCb022B3A8a334618f5cea15A046C10FEE1352f"
+  const dividedAddr = "0x06245F89576536E9cF844C5804a8ad1CCeDb2642"
 
   await tonVfactory.setLogic(
     logicaddr


### PR DESCRIPTION
TON Staker 에어드랍 Vault의 dividiedPool 주소(에어드랍 컨트랙트)에 deploy 코드에 있는 잘못된 주소가 설정되어 있어 정정합니다.